### PR TITLE
Fix warning in PHP7.2 when we count a non-countable value

### DIFF
--- a/src/PDO/Statement/StatementContainer.php
+++ b/src/PDO/Statement/StatementContainer.php
@@ -511,7 +511,7 @@ abstract class StatementContainer
     protected function setPlaceholders(array $values)
     {
         foreach ($values as $value) {
-            $this->placeholders[] = $this->setPlaceholder('?', is_null($value) ? 1 : sizeof($value));
+            $this->placeholders[] = $this->setPlaceholder('?', !(!is_null($value) && (is_array($value) || $value instanceof \Countable)) ? 1 : sizeof($value));
         }
     }
 


### PR DESCRIPTION
Hey,

Quick fix to #92 

I tried if it didn't break anything with the following code :

```php
function getCount($value) {
    return is_null($value) ? 1 : sizeof($value);
}

function getNewCount($value) {
    return !(!is_null($value) && (is_array($value) || $value instanceof \Countable)) ? 1 : sizeof($value);
}

class TestCount implements \Countable
{
    public function count()
    {
        return 3;
    }
}

var_dump(getCount(0) === getNewCount(0));
var_dump(getCount(1) === getNewCount(1));
var_dump(getCount([0, 1]) === getNewCount([0, 1]));
var_dump(getCount(false) === getNewCount(false));
var_dump(getCount(true) === getNewCount(true));
var_dump(getCount(null) === getNewCount(null));
var_dump(getCount("test") === getNewCount("test"));
var_dump(getCount(["test" => 3]) === getNewCount(["test" => 3]));
var_dump(getCount(["test" => 3, "moo" => 4]) === getNewCount(["test" => 3, "moo" => 4]));
var_dump(getCount(["test", "moo"]) === getNewCount(["test", "moo"]));
var_dump(getCount([]) === getNewCount([]));
var_dump(getCount(["test"]) === getNewCount(["test"]));
var_dump(getCount(new TestCount()) === getNewCount(new TestCount()));
```

Let me know if I forgot any edge case :)