### PR TITLE
sizeof() warning fix for PHP 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Slim-PDO
 
-[![Latest Stable Version](https://poser.pugx.org/slim/pdo/v/stable)](https://packagist.org/packages/slim/pdo)
-[![Total Downloads](https://poser.pugx.org/slim/pdo/downloads)](https://packagist.org/packages/slim/pdo)
-[![Latest Unstable Version](https://poser.pugx.org/slim/pdo/v/unstable)](https://packagist.org/packages/slim/pdo)
-[![License](https://poser.pugx.org/slim/pdo/license)](https://packagist.org/packages/slim/pdo)
-
 PDO database library for Slim Framework
+
+This is a fork of Fabien's project with support for PHP 7.2.
+
+Please refer to the main package at https://github.com/faaPz/Slim-PDO for pull requests, support and documentation.
 
 ### Installation
 
@@ -13,7 +12,7 @@ Use [Composer](https://getcomposer.org/)
 
 ```json
 "require": {
-    "slim/pdo": "~1.10"
+    "kimoslim/pdo": "~1.10"
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kimoslim/pdo",
-    "description": "PDO database library for Slim Framework",
+    "description": "PHP 7.2 Compatible Fork of PDO database library for Slim Framework",
     "version": "1.10.2",
     "type": "library",
     "keywords": ["pdo", "database", "slim", "framework"],
@@ -21,8 +21,8 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/kimosabi77/Slim-PDO/issues",
-        "docs": "https://github.com/kimosabi77/Slim-PDO/blob/master/docs/README.md"
+        "issues": "https://github.com/FaaPz/Slim-PDO/issues",
+        "docs": "https://github.com/FaaPz/Slim-PDO/blob/master/docs/README.md"
     },
     "require": {
         "php": ">=5.3.0",

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,17 @@
 {
-    "name": "slim/pdo",
+    "name": "kimosabi77/Slim-PDO",
     "description": "PDO database library for Slim Framework",
     "version": "1.10.1",
     "type": "library",
     "keywords": ["pdo", "database", "slim", "framework"],
-    "homepage": "https://github.com/FaaPz/Slim-PDO",
+    "homepage": "https://github.com/kimosabi77/Slim-PDO",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Fabian de Laender",
-            "email": "fabian@faapz.nl",
-            "homepage": "http://faapz.nl",
-            "role": "Developer"
-        }
-    ],
+    "authors": [{
+        "name": "Fabian de Laender",
+        "email": "fabian@faapz.nl",
+        "homepage": "http://faapz.nl",
+        "role": "Developer"
+    }],
     "support": {
         "issues": "https://github.com/FaaPz/Slim-PDO/issues",
         "docs": "https://github.com/FaaPz/Slim-PDO/blob/master/docs/README.md"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "slim/pdo",
+    "name": "kimoslim/pdo",
     "description": "PDO database library for Slim Framework",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "type": "library",
     "keywords": ["pdo", "database", "slim", "framework"],
     "homepage": "https://github.com/FaaPz/Slim-PDO",
@@ -12,11 +12,17 @@
             "email": "fabian@faapz.nl",
             "homepage": "http://faapz.nl",
             "role": "Developer"
+        },
+        {
+            "name": "Kim Richardson",
+            "email": "krichardson@viewdale.com.au",
+            "homepage": "https://viewdaleit.com.au",
+            "role": "Developer"
         }
     ],
     "support": {
-        "issues": "https://github.com/FaaPz/Slim-PDO/issues",
-        "docs": "https://github.com/FaaPz/Slim-PDO/blob/master/docs/README.md"
+        "issues": "https://github.com/kimosabi77/Slim-PDO/issues",
+        "docs": "https://github.com/kimosabi77/Slim-PDO/blob/master/docs/README.md"
     },
     "require": {
         "php": ">=5.3.0",

--- a/src/PDO/Statement/StatementContainer.php
+++ b/src/PDO/Statement/StatementContainer.php
@@ -511,7 +511,7 @@ abstract class StatementContainer
     protected function setPlaceholders(array $values)
     {
         foreach ($values as $value) {
-            $this->placeholders[] = $this->setPlaceholder('?', is_null($value) ? 1 : sizeof($value));
+            $this->placeholders[] = $this->setPlaceholder('?', is_null($value) ? 1 : (is_array($value)?sizeof($value):1));
         }
     }
 


### PR DESCRIPTION
Added ternary statement to only use sizeof when value is an array. 

This solves warnings on PHP 7.2