### PR TITLE
Fixing self vs $this type-hint return type.

### DIFF
--- a/src/AdvancedStatement.php
+++ b/src/AdvancedStatement.php
@@ -24,7 +24,7 @@ abstract class AdvancedStatement extends AbstractStatement
     /**
      * @param Clause\Join $clause
      *
-     * @return self
+     * @return $this
      */
     public function join(Clause\Join $clause)
     {
@@ -36,7 +36,7 @@ abstract class AdvancedStatement extends AbstractStatement
     /**
      * @param Clause\Conditional $clause
      *
-     * @return self
+     * @return $this
      */
     public function where(Clause\Conditional $clause)
     {
@@ -49,7 +49,7 @@ abstract class AdvancedStatement extends AbstractStatement
      * @param string $column
      * @param string $direction
      *
-     * @return self
+     * @return $this
      */
     public function orderBy(string $column, string $direction = '')
     {
@@ -61,7 +61,7 @@ abstract class AdvancedStatement extends AbstractStatement
     /**
      * @param Clause\Limit|null $limit
      *
-     * @return self
+     * @return $this
      */
     public function limit(?Clause\Limit $limit)
     {

--- a/src/Statement/Call.php
+++ b/src/Statement/Call.php
@@ -37,7 +37,7 @@ class Call extends AbstractStatement
     /**
      * @param Clause\Method $procedure
      *
-     * @return self
+     * @return $this
      */
     public function method(Clause\Method $procedure) : self
     {

--- a/src/Statement/Select.php
+++ b/src/Statement/Select.php
@@ -89,7 +89,7 @@ class Select extends AdvancedStatement
     /**
      * @param Clause\Join $clause
      *
-     * @return self
+     * @return $this
      */
     public function join(Clause\Join $clause) : self
     {

--- a/src/Statement/Update.php
+++ b/src/Statement/Update.php
@@ -34,7 +34,7 @@ class Update extends AdvancedStatement
     /**
      * @param string $table
      *
-     * @return self
+     * @return $this
      */
     public function table(string $table) : self
     {
@@ -46,7 +46,7 @@ class Update extends AdvancedStatement
     /**
      * @param array<string, mixed> $pairs
      *
-     * @return self
+     * @return $this
      */
     public function pairs(array $pairs) : self
     {
@@ -59,7 +59,7 @@ class Update extends AdvancedStatement
      * @param string $column
      * @param mixed  $value
      *
-     * @return self
+     * @return $this
      */
     public function set(string $column, $value) : self
     {


### PR DESCRIPTION
 Apparently this means different things in terms of inheritance.  Using self inherits the current implementing class where $this inherits the accrual inherited class.