### PR TITLE
Use the sql generic 'Limit Offset' syntax, not MySQL only one

### DIFF
--- a/src/Clause/Limit.php
+++ b/src/Clause/Limit.php
@@ -48,7 +48,7 @@ class Limit implements QueryInterface
     {
         $sql = 'LIMIT ?';
         if ($this->offset !== null) {
-            $sql .= ', ?';
+            $sql .= ' OFFSET ?';
         }
 
         return $sql;

--- a/tests/Statement/SelectTest.php
+++ b/tests/Statement/SelectTest.php
@@ -158,7 +158,7 @@ class SelectTest extends TestCase
             ->from('test')
             ->limit(new Clause\Limit(5, 25));
 
-        $this->assertStringEndsWith('test LIMIT ?, ?', $this->subject->__toString());
+        $this->assertStringEndsWith('test LIMIT ? OFFSET ?', $this->subject->__toString());
     }
 
     public function testToStringWithoutTable()


### PR DESCRIPTION
Using `LIMIT a OFFSET b` on `\FaaPz\PDO\Clause\Limit#__toString` that is the generic Limit syntax instead of `LIMIT a, b` which is only for MySQL

(You can take for reference the [sql.sh](https://sql.sh/cours/limit) website or this other one: [https://www.sqltutorial.org/sql-limit/](https://www.sqltutorial.org/sql-limit/))

_Thank you !_