### PR TITLE
add parenthesis in query

### DIFF
--- a/src/Clause/Parenthesis.php
+++ b/src/Clause/Parenthesis.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @license MIT
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace FaaPz\PDO\Clause;
+
+class Parenthesis extends Conditional
+{
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return '('.parent::__toString().')';
+    }
+}

--- a/tests/Clause/ParenthesisTest.php
+++ b/tests/Clause/ParenthesisTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @license MIT
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace FaaPz\PDO\Test;
+
+use FaaPz\PDO\Clause\Parenthesis;
+use FaaPz\PDO\Clause\Conditional;
+use FaaPz\PDO\Clause\Method;
+use FaaPz\PDO\Clause\Raw;
+use PHPUnit\Framework\TestCase;
+
+class ParenthesisTest extends TestCase
+{
+    public function testToString()
+    {
+        $subject = new Parenthesis('col', '=', 'val');
+
+        $this->assertEquals('(col = ?)', $subject->__toString());
+    }
+
+    public function testToStringWithAndConditional()
+    {
+        $subject = new Parenthesis(new Conditional('col', '=', 'val'), 'AND', new Conditional('col', '!=', 'val'));
+
+        $this->assertEquals('(col = ? AND col != ?)', $subject->__toString());
+    }
+
+    public function testToStringWithAndOrConditional()
+    {
+        $subject1 = new Parenthesis(new Conditional('col', '=', 'val'), 'AND', new Conditional('col', '!=', 'val'));
+        $subject2 = new Parenthesis(new Conditional('col', '=', 'val'), 'AND', new Conditional('col', '!=', 'val'));
+        $subject  = new Conditional($subject1, 'OR', $subject2);
+
+        $this->assertEquals('(col = ? AND col != ?) OR (col = ? AND col != ?)', $subject->__toString());
+    }
+
+}


### PR DESCRIPTION
Sametimes we need to write a query with parenthesis like this exemple : 

```
WHERE ( categorie = 'informatique' AND stock < 20 )
OR ( categorie = 'fourniture' AND stock < 200 )
```

So with this merge we will be able to write it like this :

```
$subject1 = new Parenthesis(new Conditional('categorie', '=', 'informatique'), 'AND', new Conditional('stock', '<', 20));
$subject2 = new Parenthesis(new Conditional('categorie', '=', 'fourniture'), 'AND', new Conditional('stock', '<', 200));
$subject  = new Conditional($subject1, 'OR', $subject2);
```
