### PR TITLE
Include advanced statement methods in DeleteInterface

### DIFF
--- a/src/Statement/DeleteInterface.php
+++ b/src/Statement/DeleteInterface.php
@@ -7,9 +7,9 @@
 
 namespace FaaPz\PDO\Statement;
 
-use FaaPz\PDO\StatementInterface;
+use FaaPz\PDO\AdvancedStatementInterface;
 
-interface DeleteInterface extends StatementInterface
+interface DeleteInterface extends AdvancedStatementInterface
 {
     /**
      * @param string|array<string, string> $table


### PR DESCRIPTION
Adapt `DeleteInterface` to match the actual `Delete` implementation which inherits from `AdvancedStatement` to provide methods like `where()`.

Otherwise static analysis tools like phpstan will trigger errors when `where()` is used in a delete statement:

```
$db->delete()->from($table)->where($condition);
```